### PR TITLE
Added new flag for measurementsFinished to fix tooltip flash

### DIFF
--- a/src/tooltip.js
+++ b/src/tooltip.js
@@ -277,6 +277,7 @@ class Tooltip extends Component<Props, State> {
           } else if (contentSize.width !== null) {
             this._updateGeometry({ contentSize });
           }
+          this.setState({ measurementsFinished: true })
         },
       );
     });
@@ -296,7 +297,6 @@ class Tooltip extends Component<Props, State> {
         waitingToComputeGeom: false,
       },
       () => {
-        this.setState({ measurementsFinished: true })
         this._startAnimation({ show: true })
       }
     );
@@ -306,16 +306,11 @@ class Tooltip extends Component<Props, State> {
     const geom = this.computeGeometry({ contentSize });
     const { tooltipOrigin, anchorPoint, placement } = geom;
 
-    this.setState(
-      {
-        tooltipOrigin,
-        anchorPoint,
-        placement,
-      },
-      () => {
-      this.setState({ measurementsFinished: true })
-      }
-    );
+    this.setState({
+      tooltipOrigin,
+      anchorPoint,
+      placement,
+    });
   };
 
   computeGeometry = ({ contentSize, placement }: ComputeGeomProps) => {


### PR DESCRIPTION
This fixes an issue where the tooltip and child would flash in the incorrect position. The tooltip was rendering before the measurement was finished. You can see the original issue here: https://github.com/zachrnolan/tooltip-minimal-example.

This could definitely use another set of eyes. Let me know if there's anything that looks off.