### PR TITLE
feat(walkthrough-context): wrap tooltip children in a boolean React Context

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,3 +87,22 @@ When providing either of these functions, React Native Walkthrough Tooltip will 
 **NOTE: This will disable and override any touch events on your child element**
 
 One possible use case for these functions would be a scenerio where you are highlighting new functionality and want to restrict a user to ONLY do a certain action when they press on an element. While perhaps uncommon, this use case was relevant for another library I am working on, so it may be useful for you. When these props are NOT provided, all touch events on children occur as expected.
+
+### TooltipChildrenConsumer
+
+[React Context](https://reactjs.org/docs/context.html) consumer that can be used to distinguish "real" children rendered inside parent's layout from their copies rendered inside tooltip's modal. The duplicate child rendered in the tooltip modal is wrapped in a Context.Provider which provides object with prop `tooltipDuplicate` set to `true`, so informed decisions may be made, if necessary, based on where the child rendered.
+```js
+import Tooltip, { TooltipChildrenConsumer } from 'react-native-walkthrough-tooltip';
+...
+<Tooltip withContext>
+  <ComponentA />
+  <ComponentB>
+    <TooltipChildrenConsumer>
+      {({ tooltipDuplicate }) => (
+        // will only assign a ref to the original component
+        <FlatList {...(!tooltipDuplicate && { ref: this.listRef })} />
+      )}
+    </WalkthroughConsumer>
+  </ComponentB>
+</Tooltip>
+```

--- a/package.json
+++ b/package.json
@@ -45,6 +45,9 @@
     "react-dom": "16.3.3",
     "react-native": "^0.55.3"
   },
+  "peerDependencies": {
+    "@types/react": "^16.8.24"
+  },
   "jest": {
     "preset": "react-native",
     "collectCoverageFrom": [

--- a/src/tooltip-children.context.js
+++ b/src/tooltip-children.context.js
@@ -1,0 +1,3 @@
+import React from 'react';
+
+export default React.createContext({ tooltipDuplicate: false });

--- a/src/tooltip.d.ts
+++ b/src/tooltip.d.ts
@@ -88,6 +88,23 @@ declare module 'react-native-walkthrough-tooltip' {
 
     /**
      ```js
+        // Usage Example
+        import Tooltip, { TooltipChildrenConsumer } from 'react-native-walkthrough-tooltip';
+        <Tooltip>
+            <TooltipChildrenConsumer>
+                {({ tooltipDuplicate }) => (
+                    <ScrollView scrollEnabled={!tooltipDuplicate}>
+                        {children}
+                    </ScrollView>
+                )}
+            </TooltipChildrenConsumer>
+        </Tooltip>
+    ```
+     */
+    export const TooltipChildrenConsumer: React.Consumer<{ tooltipDuplicate: boolean }>;
+
+    /**
+     ```js
         // Simple Usage
         import Tooltip from 'react-native-walkthrough-tooltip';
         <Tooltip

--- a/src/tooltip.js
+++ b/src/tooltip.js
@@ -20,6 +20,7 @@ import {
   computeRightGeometry,
 } from './geom';
 import styles from './styles';
+import TooltipChildrenContext from './tooltip-children.context';
 
 const SCREEN_HEIGHT = Dimensions.get('window').height;
 const SCREEN_WIDTH = Dimensions.get('window').width;
@@ -41,6 +42,9 @@ const invertPlacement = (placement) => {
       return placement;
   }
 };
+
+const TooltipChildrenProvider = TooltipChildrenContext.Provider;
+export const TooltipChildrenConsumer = TooltipChildrenContext.Consumer;
 
 class Tooltip extends Component {
   static defaultProps = {
@@ -523,7 +527,9 @@ class Tooltip extends Component {
           justifyContent: 'center',
         }}
       >
-        {children}
+        <TooltipChildrenProvider value={{ tooltipDuplicate: true }}>
+          {children}
+        </TooltipChildrenProvider>
       </View>
     );
 


### PR DESCRIPTION
Can be used to distinguish between "real" children and tooltip children.

Solves #40.