### PR TITLE
fix(tooltip-children-context): export entire Context instead of Consumer

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,21 +88,21 @@ When providing either of these functions, React Native Walkthrough Tooltip will 
 
 One possible use case for these functions would be a scenerio where you are highlighting new functionality and want to restrict a user to ONLY do a certain action when they press on an element. While perhaps uncommon, this use case was relevant for another library I am working on, so it may be useful for you. When these props are NOT provided, all touch events on children occur as expected.
 
-### TooltipChildrenConsumer
+### TooltipChildrenContext
 
-[React Context](https://reactjs.org/docs/context.html) consumer that can be used to distinguish "real" children rendered inside parent's layout from their copies rendered inside tooltip's modal. The duplicate child rendered in the tooltip modal is wrapped in a Context.Provider which provides object with prop `tooltipDuplicate` set to `true`, so informed decisions may be made, if necessary, based on where the child rendered.
+[React Context](https://reactjs.org/docs/context.html) that can be used to distinguish "real" children rendered inside parent's layout from their copies rendered inside tooltip's modal. The duplicate child rendered in the tooltip modal is wrapped in a Context.Provider which provides object with prop `tooltipDuplicate` set to `true`, so informed decisions may be made, if necessary, based on where the child rendered.
 ```js
-import Tooltip, { TooltipChildrenConsumer } from 'react-native-walkthrough-tooltip';
+import Tooltip, { TooltipChildrenContext } from 'react-native-walkthrough-tooltip';
 ...
-<Tooltip withContext>
+<Tooltip>
   <ComponentA />
   <ComponentB>
-    <TooltipChildrenConsumer>
+    <TooltipChildrenContext.Consumer>
       {({ tooltipDuplicate }) => (
         // will only assign a ref to the original component
         <FlatList {...(!tooltipDuplicate && { ref: this.listRef })} />
       )}
-    </WalkthroughConsumer>
+    </TooltipChildrenContext.Consumer>
   </ComponentB>
 </Tooltip>
 ```

--- a/src/tooltip.d.ts
+++ b/src/tooltip.d.ts
@@ -89,19 +89,19 @@ declare module 'react-native-walkthrough-tooltip' {
     /**
      ```js
         // Usage Example
-        import Tooltip, { TooltipChildrenConsumer } from 'react-native-walkthrough-tooltip';
+        import Tooltip, { TooltipChildrenContext } from 'react-native-walkthrough-tooltip';
         <Tooltip>
-            <TooltipChildrenConsumer>
+            <TooltipChildrenContext.Consumer>
                 {({ tooltipDuplicate }) => (
                     <ScrollView scrollEnabled={!tooltipDuplicate}>
                         {children}
                     </ScrollView>
                 )}
-            </TooltipChildrenConsumer>
+            </TooltipChildrenContext.Consumer>
         </Tooltip>
     ```
      */
-    export const TooltipChildrenConsumer: React.Consumer<{ tooltipDuplicate: boolean }>;
+    export const TooltipChildrenContext: React.Context<{ tooltipDuplicate: boolean }>;
 
     /**
      ```js

--- a/src/tooltip.js
+++ b/src/tooltip.js
@@ -22,6 +22,8 @@ import {
 import styles from './styles';
 import TooltipChildrenContext from './tooltip-children.context';
 
+export { TooltipChildrenContext };
+
 const SCREEN_HEIGHT = Dimensions.get('window').height;
 const SCREEN_WIDTH = Dimensions.get('window').width;
 
@@ -42,9 +44,6 @@ const invertPlacement = (placement) => {
       return placement;
   }
 };
-
-const TooltipChildrenProvider = TooltipChildrenContext.Provider;
-export const TooltipChildrenConsumer = TooltipChildrenContext.Consumer;
 
 class Tooltip extends Component {
   static defaultProps = {
@@ -527,9 +526,9 @@ class Tooltip extends Component {
           justifyContent: 'center',
         }}
       >
-        <TooltipChildrenProvider value={{ tooltipDuplicate: true }}>
+        <TooltipChildrenContext.Provider value={{ tooltipDuplicate: true }}>
           {children}
-        </TooltipChildrenProvider>
+        </TooltipChildrenContext.Provider>
       </View>
     );
 


### PR DESCRIPTION
Following #41 