### PR TITLE
Fix adjusted content size for center placement

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-walkthrough-tooltip",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "An inline wrapper for calling out React Native components via tooltip",
   "main": "src/tooltip.js",
   "scripts": {

--- a/src/geom.js
+++ b/src/geom.js
@@ -142,12 +142,8 @@ const computeTopGeometry = ({
     adjustedContentSize.height = topPlacementBottomBound - tooltipOrigin.y;
   }
 
-  if (
-    tooltipOrigin.x + contentSize.width >
-    windowDims.width - displayInsets.right
-  ) {
-    tooltipOrigin.x =
-      windowDims.width - displayInsets.right - contentSize.width;
+  if (tooltipOrigin.x + contentSize.width > maxWidth) {
+    tooltipOrigin.x = displayInsets.left;
   }
 
   return {
@@ -214,12 +210,8 @@ const computeBottomGeometry = ({
       windowDims.height - displayInsets.bottom - tooltipOrigin.y;
   }
 
-  if (
-    tooltipOrigin.x + contentSize.width >
-    windowDims.width - displayInsets.right
-  ) {
-    tooltipOrigin.x =
-      windowDims.width - displayInsets.right - contentSize.width;
+  if (tooltipOrigin.x + contentSize.width > maxWidth) {
+    tooltipOrigin.x = displayInsets.left;
   }
 
   return {
@@ -285,12 +277,8 @@ const computeLeftGeometry = ({
     adjustedContentSize.width = leftPlacementRightBound - tooltipOrigin.x;
   }
 
-  if (
-    tooltipOrigin.y + contentSize.height >
-    windowDims.height - displayInsets.bottom
-  ) {
-    tooltipOrigin.y =
-      windowDims.height - displayInsets.bottom - contentSize.height;
+  if (tooltipOrigin.y + contentSize.height > maxHeight) {
+    tooltipOrigin.y = displayInsets.top;
   }
 
   return {
@@ -358,12 +346,8 @@ const computeRightGeometry = ({
       windowDims.width - displayInsets.right - tooltipOrigin.x;
   }
 
-  if (
-    tooltipOrigin.y + contentSize.height >
-    windowDims.height - displayInsets.bottom
-  ) {
-    tooltipOrigin.y =
-      windowDims.height - displayInsets.bottom - contentSize.height;
+  if (tooltipOrigin.y + contentSize.height > maxHeight) {
+    tooltipOrigin.y = displayInsets.top;
   }
 
   return {

--- a/src/geom.js
+++ b/src/geom.js
@@ -49,10 +49,9 @@ const makeChildlessRect = ({ displayInsets, windowDims, placement }) => {
   }
 };
 
-const computeCenterGeomerty = ({
+const computeCenterGeometry = ({
   childRect,
   contentSize,
-  arrowSize,
   displayInsets,
   windowDims
 }) => {
@@ -62,17 +61,17 @@ const computeCenterGeomerty = ({
     windowDims.height - (displayInsets.top + displayInsets.bottom);
 
   const adjustedContentSize = new Size(
-    Math.min(maxWidth, contentSize.width),
-    Math.min(maxHeight, contentSize.height)
+    contentSize.width >= maxWidth ? maxWidth : -1,
+    contentSize.height >= maxHeight ? maxHeight : -1
   );
 
   const tooltipOrigin = new Point(
-    adjustedContentSize.width === maxWidth
-      ? displayInsets.left
-      : (maxWidth - adjustedContentSize.width) / 2 + displayInsets.left,
-    adjustedContentSize.height === maxHeight
-      ? displayInsets.top
-      : (maxHeight - adjustedContentSize.height) / 2 + displayInsets.top
+    adjustedContentSize.width === -1
+      ? (maxWidth - contentSize.width) / 2 + displayInsets.left
+      : displayInsets.left,
+    adjustedContentSize.height === -1
+      ? (maxHeight - contentSize.height) / 2 + displayInsets.top
+      : displayInsets.top
   );
 
   const anchorPoint = new Point(
@@ -364,7 +363,7 @@ export {
   Rect,
   swapSizeDimmensions,
   makeChildlessRect,
-  computeCenterGeomerty,
+  computeCenterGeometry,
   computeTopGeometry,
   computeBottomGeometry,
   computeLeftGeometry,

--- a/src/styles.js
+++ b/src/styles.js
@@ -137,14 +137,13 @@ const styleGenerator = (styleGeneratorProps) => {
     placement
   } = styleGeneratorProps;
 
-  const adjustedSizeAvailable = adjustedContentSize.width;
+  const { height, width } = adjustedContentSize;
   const { backgroundColor } = ownProps;
 
   const contentStyle = [
     styles.content,
-    adjustedSizeAvailable && placement !== "center"
-      ? { ...adjustedContentSize }
-      : {},
+    height > 0 && { height }, // ignore special case of -1 with center placement (and 0 when not yet measured)
+    width > 0 && { width }, // ignore special case of -1 with center placement (and 0 when not yet measured)
     ownProps.contentStyle
   ];
 
@@ -173,7 +172,9 @@ const styleGenerator = (styleGeneratorProps) => {
     ],
     containerStyle: [
       styles.container,
-      adjustedSizeAvailable && measurementsFinished && styles.containerVisible
+      adjustedContentSize.width !== 0 &&
+        measurementsFinished &&
+        styles.containerVisible
     ],
     contentStyle,
     tooltipStyle: [

--- a/src/styles.js
+++ b/src/styles.js
@@ -142,7 +142,9 @@ const styleGenerator = (styleGeneratorProps) => {
 
   const contentStyle = [
     styles.content,
-    adjustedSizeAvailable && { ...adjustedContentSize },
+    adjustedSizeAvailable && placement !== "center"
+      ? { ...adjustedContentSize }
+      : {},
     ownProps.contentStyle
   ];
 

--- a/src/tooltip.js
+++ b/src/tooltip.js
@@ -14,7 +14,7 @@ import {
   Rect,
   swapSizeDimmensions,
   makeChildlessRect,
-  computeCenterGeomerty,
+  computeCenterGeometry,
   computeTopGeometry,
   computeBottomGeometry,
   computeLeftGeometry,
@@ -319,7 +319,7 @@ class Tooltip extends Component {
       innerPlacement === "center" &&
       React.Children.count(this.props.children) === 0
     ) {
-      return computeCenterGeomerty(options);
+      return computeCenterGeometry(options);
     }
 
     switch (innerPlacement) {


### PR DESCRIPTION
- this fixes an issue where the adjustedContentSize was not allowing the content of a center placement to grow
- (behinds the scenes details) when the original contentSize fits inside the displayInset, the adjusted size is set to `-1` and then the size for that dimension is NOT applied to the content. but if the size was too large, the adjusted size IS used (i.e. the best of both worlds 💪🏻)