### PR TITLE
Fix Type Definition: useInteractionManager and useReactNativeModal as optional props

### DIFF
--- a/src/tooltip.d.ts
+++ b/src/tooltip.d.ts
@@ -87,13 +87,13 @@ declare module "react-native-walkthrough-tooltip" {
      * from InteractionManager.runAfterInteractions is executed. Can be useful if you need
      * to wait for navigation transitions to complete, etc
      */
-    useInteractionManager: boolean;
+    useInteractionManager?: boolean;
 
     /**
      * When false, will not use a React Native Modal component to display tooltip,
      * but rather an absolutely positioned view
      */
-    useReactNativeModal: boolean;
+    useReactNativeModal?: boolean;
   }
 
   /**


### PR DESCRIPTION
useInteractionManager and useReactNativeModal should not be required. 

![Captura de Tela 2019-10-08 às 12 02 48](https://user-images.githubusercontent.com/7540050/66407429-91788500-e9c3-11e9-8880-4d049242dd39.png)
