### PR TITLE
prevent update geometry getting called in a loop on some devices

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-walkthrough-tooltip",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "An inline wrapper for calling out React Native components via tooltip",
   "main": "src/tooltip.js",
   "scripts": {

--- a/src/tooltip.js
+++ b/src/tooltip.js
@@ -217,15 +217,17 @@ class Tooltip extends Component {
   };
 
   measureContent = (e) => {
-    const { width, height } = e.nativeEvent.layout;
-    const contentSize = new Size(width, height);
+    if (!this.state.measurementsFinished) {
+      const { width, height } = e.nativeEvent.layout;
+      const contentSize = new Size(width, height);
 
-    this.setState({ contentSize }, () => {
-      this._updateGeometry();
-    });
+      this.setState({ contentSize }, () => {
+        this._updateGeometry();
+      });
 
-    if (React.Children.count(this.props.children) === 0) {
-      this.doChildlessPlacement();
+      // if (React.Children.count(this.props.children) === 0) {
+      //   this.doChildlessPlacement();
+      // }
     }
   };
 
@@ -237,7 +239,9 @@ class Tooltip extends Component {
       },
       () => {
         this.isMeasuringChild = false;
-        this._updateGeometry();
+        if (this.state.contentSize.width) {
+          this._updateGeometry();
+        }
       }
     );
   };

--- a/src/tooltip.js
+++ b/src/tooltip.js
@@ -217,18 +217,12 @@ class Tooltip extends Component {
   };
 
   measureContent = (e) => {
-    if (!this.state.measurementsFinished) {
-      const { width, height } = e.nativeEvent.layout;
-      const contentSize = new Size(width, height);
+    const { width, height } = e.nativeEvent.layout;
+    const contentSize = new Size(width, height);
 
-      this.setState({ contentSize }, () => {
-        this._updateGeometry();
-      });
-
-      // if (React.Children.count(this.props.children) === 0) {
-      //   this.doChildlessPlacement();
-      // }
-    }
+    this.setState({ contentSize }, () => {
+      this._updateGeometry();
+    });
   };
 
   onChildMeasurementComplete = (rect) => {


### PR DESCRIPTION
On some devices, there was a continuous loop with the measuring and layout callbacks, so the tooltip bubble would flicker rapidly between two sizes. This alleviates that issue.