### PR TITLE
add feature to adjust missplaced component

### DIFF
--- a/src/tooltip.js
+++ b/src/tooltip.js
@@ -70,7 +70,8 @@ class Tooltip extends Component {
     showChildInTooltip: true,
     supportedOrientations: ["portrait", "landscape"],
     useInteractionManager: false,
-    useReactNativeModal: true
+    useReactNativeModal: true,
+    topAdjustment: 0
   };
 
   static propTypes = {
@@ -323,6 +324,7 @@ class Tooltip extends Component {
 
   renderChildInTooltip = () => {
     const { height, width, x, y } = this.state.childRect;
+    const { topAdjustment } = this.props;
 
     const onTouchEnd = () => {
       if (this.props.closeOnChildInteraction) {
@@ -339,7 +341,7 @@ class Tooltip extends Component {
             position: "absolute",
             height,
             width,
-            top: y,
+            top: y + topAdjustment,
             left: x,
             alignItems: "center",
             justifyContent: "center"


### PR DESCRIPTION
Hi,

For some reason on android device the component not in the right place on vertical axis.
so I am adding one props for adjust it.

<img width="387" alt="Screen Shot 2019-10-14 at 17 32 34" src="https://user-images.githubusercontent.com/25797860/66745351-e8d99200-eea8-11e9-82f8-b7d0be06aa6d.png">

toUse add props "topAdjustment"

```
<Tooltip
  backgroundStyle={{ marginTop: !isAndroid ? 0 : -24 }}
  topAdjustment={isAndroid ? -24 : 0}
  arrowStyle={{ marginLeft: 5 }}
  contentStyle={{ marginLeft: 10 }}
  isVisible={tooltip}
  content={<Text>Awesome Stuff</Text>}
  placement="bottom"
>
```

thank you