### PR TITLE
Fix measurement issues

### DIFF
--- a/src/geom.js
+++ b/src/geom.js
@@ -26,25 +26,25 @@ const swapSizeDimmensions = size => new Size(size.height, size.width);
 const makeChildlessRect = ({ displayInsets, windowDims, placement }) => {
   switch (placement) {
     case 'bottom':
-      return new Rect(windowDims.width / 2, displayInsets.top, 0, 0);
+      return new Rect(windowDims.width / 2, displayInsets.top, 1, 1);
 
     case 'right':
-      return new Rect(displayInsets.left, windowDims.height / 2, 0, 0);
+      return new Rect(displayInsets.left, windowDims.height / 2, 1, 1);
 
     case 'left':
       return new Rect(
         windowDims.width - displayInsets.right,
         windowDims.height / 2,
-        0,
-        0,
+        1,
+        1,
       );
     case 'top':
     default:
       return new Rect(
         windowDims.width / 2,
         windowDims.height - displayInsets.bottom,
-        0,
-        0,
+        1,
+        1,
       );
   }
 };
@@ -144,7 +144,7 @@ const computeTopGeometry = ({
 
   if (tooltipOrigin.x + contentSize.width > maxWidth) {
     tooltipOrigin.x =
-      windowDims.width - displayInsets.right - adjustedContentSize.width;
+      displayInsets.left + (maxWidth - adjustedContentSize.width) / 2;
   }
 
   return {
@@ -213,7 +213,7 @@ const computeBottomGeometry = ({
 
   if (tooltipOrigin.x + contentSize.width > maxWidth) {
     tooltipOrigin.x =
-      windowDims.width - displayInsets.right - adjustedContentSize.width;
+      displayInsets.left + (maxWidth - adjustedContentSize.width) / 2;
   }
 
   return {


### PR DESCRIPTION
Fixed:
- Tooltips with adjusted content size that had `top` or `bottom` placement were not quite centered in the view, but now they are
- If `isVisible` is true when the component is constructed, `measurementsFinished` was incorrectly set to `true` before the contentSize was measured. This was causing some erroneous locations for the tooltip
- If `isVisible` is true when the component is constructed, AND the prop `useInteractionManager` is true, the measurements would never occur. Now they should 🤞🏼
