### PR TITLE
check that values from measure function are not undefined

### DIFF
--- a/src/tooltip.js
+++ b/src/tooltip.js
@@ -246,7 +246,13 @@ class Tooltip extends Component {
           this.childWrapper.current.measure(
             (x, y, width, height, pageX, pageY) => {
               const childRect = new Rect(pageX, pageY, width, height);
-              this.onChildMeasurementComplete(childRect);
+              if (
+                Object.values(childRect).every(value => value !== undefined)
+              ) {
+                this.onChildMeasurementComplete(childRect);
+              } else {
+                this.doChildlessPlacement();
+              }
             },
           );
         } else {


### PR DESCRIPTION
In rare cases, the `measure` function on a React Native View will return `undefined` values, likely before they are actually known. This helps prevent a crash and/or incorrect `childRect` values by checking first that all values are defined