### PR TITLE
Fix: Issue #68. A workaround to fix the Android wrong top position for container

### DIFF
--- a/src/styles.js
+++ b/src/styles.js
@@ -135,6 +135,7 @@ const styleGenerator = styleGeneratorProps => {
     measurementsFinished,
     ownProps,
     placement,
+    topAdjustment,
   } = styleGeneratorProps;
 
   const { height, width } = adjustedContentSize;
@@ -172,9 +173,14 @@ const styleGenerator = styleGeneratorProps => {
     ],
     containerStyle: [
       styles.container,
-      adjustedContentSize.width !== 0 &&
-        measurementsFinished &&
-        styles.containerVisible,
+      StyleSheet.compose(
+        adjustedContentSize.width !== 0 &&
+          measurementsFinished &&
+          styles.containerVisible,
+        topAdjustment !== 0 && {
+          top: topAdjustment,
+        }
+      )
     ],
     contentStyle,
     tooltipStyle: [

--- a/src/tooltip.d.ts
+++ b/src/tooltip.d.ts
@@ -99,6 +99,15 @@ declare module 'react-native-walkthrough-tooltip' {
      *The distance between the tooltip-rendered child and the arrow pointing to it
     */
     childContentSpacing?: number;
+
+    /**
+     *The top value to set for the container. This is useful to fix the issue with StatusBar in Android.
+     ```js
+        // Usage Example
+        <Tooltip topAdjustment={Platform.OS === 'android' ? -StatusBar.currentHeight : 0} />
+     ```
+    */
+    topAdjustment?: number;
   }
 
   /**

--- a/src/tooltip.js
+++ b/src/tooltip.js
@@ -71,6 +71,7 @@ class Tooltip extends Component {
     supportedOrientations: ['portrait', 'landscape'],
     useInteractionManager: false,
     useReactNativeModal: true,
+    topAdjustment: 0,
   };
 
   static propTypes = {
@@ -97,6 +98,7 @@ class Tooltip extends Component {
     supportedOrientations: PropTypes.arrayOf(PropTypes.string),
     useInteractionManager: PropTypes.bool,
     useReactNativeModal: PropTypes.bool,
+    topAdjustment: PropTypes.number,
   };
 
   constructor(props) {
@@ -368,6 +370,7 @@ class Tooltip extends Component {
       ownProps: { ...this.props },
       placement: this.state.placement,
       tooltipOrigin: this.state.tooltipOrigin,
+      topAdjustment: this.props.topAdjustment,
     });
 
     const hasChildren = React.Children.count(this.props.children) > 0;


### PR DESCRIPTION
This is a PR, I would like to collaborate with this small workaround to solve the problem in Android with the status bar.
Without adjustment, as current default, has issues.
![withoutadjustment](https://user-images.githubusercontent.com/16395551/71773680-5ee51680-2f37-11ea-8f82-f390cf4614cd.png)
By setting topAdjustment, looks correct:
![withadjustment](https://user-images.githubusercontent.com/16395551/71773681-5f7dad00-2f37-11ea-9077-feefc0086747.png)

I tried to update unit tests, but looks like they are outdated.