### PR TITLE
Bugfix: update content size if it changes

### DIFF
--- a/src/tooltip.js
+++ b/src/tooltip.js
@@ -144,6 +144,10 @@ class Tooltip extends Component {
 
     if (contentChanged || placementChanged || becameVisible || insetsChanged) {
       setTimeout(() => {
+        this.setState({
+          contentSize: new Size(0, 0),
+          adjustedContentSize: new Size(0, 0),
+        });
         this.measureChildRect();
       });
     }


### PR DESCRIPTION
When changing the content of a tooltip, the tooltip size did not update