### PR TITLE
Cancel interaction promise when component unmounts

### DIFF
--- a/src/tooltip.js
+++ b/src/tooltip.js
@@ -113,6 +113,7 @@ class Tooltip extends Component {
     const { isVisible, useInteractionManager } = props;
 
     this.isMeasuringChild = false;
+    this.interactionPromise = null;
 
     this.childWrapper = React.createRef();
     this.state = {
@@ -157,6 +158,7 @@ class Tooltip extends Component {
 
   componentWillUnmount() {
     Dimensions.removeEventListener('change', this.updateWindowDims);
+    this.interactionPromise && this.interactionPromise.cancel();
   }
 
   static getDerivedStateFromProps(nextProps, prevState) {
@@ -270,6 +272,9 @@ class Tooltip extends Component {
     };
 
     if (this.props.useInteractionManager) {
+      if (this.interactionPromise) {
+        this.interactionPromise.cancel();
+      }
       InteractionManager.runAfterInteractions(() => {
         doMeasurement();
       });

--- a/src/tooltip.js
+++ b/src/tooltip.js
@@ -275,7 +275,7 @@ class Tooltip extends Component {
       if (this.interactionPromise) {
         this.interactionPromise.cancel();
       }
-      InteractionManager.runAfterInteractions(() => {
+      this.interactionPromise = InteractionManager.runAfterInteractions(() => {
         doMeasurement();
       });
     } else {

--- a/src/tooltip.js
+++ b/src/tooltip.js
@@ -158,7 +158,9 @@ class Tooltip extends Component {
 
   componentWillUnmount() {
     Dimensions.removeEventListener('change', this.updateWindowDims);
-    this.interactionPromise && this.interactionPromise.cancel();
+    if (this.interactionPromise) {
+     this.interactionPromise.cancel();
+    }
   }
 
   static getDerivedStateFromProps(nextProps, prevState) {


### PR DESCRIPTION
Prevent dev warning:

```
Warning: Can't perform a React state update on an unmounted component. This is a no-op, but it indicates a memory leak in your application. To fix, cancel all subscriptions and asynchronous tasks in %s.%s, the componentWillUnmount method,
```