### PR TITLE
added expo snack example

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ Changes to handling users pressing the tooltip child element:
 
 ### Example Usage
 
+To see an expo snack example, click [here](https://snack.expo.io/@matthewliuhello/react-native-walkthrough-tooltip-example)
+
 ```js
 import Tooltip from 'react-native-walkthrough-tooltip';
 

--- a/src/tooltip.js
+++ b/src/tooltip.js
@@ -65,7 +65,7 @@ class Tooltip extends Component {
     isVisible: false,
     onClose: () => {
       console.warn(
-        '[react-native-walkthrough-tooltip] onClose prop no provided',
+        '[react-native-walkthrough-tooltip] onClose prop not provided',
       );
     },
     placement: 'center', // falls back to "top" if there ARE children


### PR DESCRIPTION
## What
mainly just added a snack example.

## Description
I think it'd be nice for first-time users be able to interact with `react-native-walkthrough-tooltip` and it'll help with context switching. Also having the snack include usage with `react-navigation` should be helpful as that seems to be a very popular library (it covers the issue https://github.com/jasongaare/react-native-walkthrough-tooltip/issues/101 that I and a few other people ran into). I tried to keep the expo snack example as short as possible.

Thank you!