### PR TITLE
Fix wrong position of tooltip when overflow screen width

### DIFF
--- a/src/geom.js
+++ b/src/geom.js
@@ -213,7 +213,7 @@ const computeBottomGeometry = ({
 
   if (tooltipOrigin.x + contentSize.width > maxWidth) {
     tooltipOrigin.x =
-      displayInsets.left + (maxWidth - adjustedContentSize.width) / 2;
+      windowDims.width - displayInsets.right - adjustedContentSize.width;
   }
 
   return {

--- a/src/geom.js
+++ b/src/geom.js
@@ -144,7 +144,7 @@ const computeTopGeometry = ({
 
   if (tooltipOrigin.x + contentSize.width > maxWidth) {
     tooltipOrigin.x =
-      displayInsets.left + (maxWidth - adjustedContentSize.width) / 2;
+      windowDims.width - displayInsets.right - adjustedContentSize.width;
   }
 
   return {


### PR DESCRIPTION
This PR fix issues: 
Fixes #78 
Fixes #82 

The problem that when the tooltip overflow screen width, it takes the center of the screen, but should right side.

Before:
![Simulator Screen Shot - iPhone 11 - 2021-02-11 at 16 29 07](https://user-images.githubusercontent.com/24809641/107650339-0d08d700-6c87-11eb-8ee5-463e88b22568.png)


After:
![Simulator Screen Shot - iPhone 11 - 2021-02-11 at 16 28 27](https://user-images.githubusercontent.com/24809641/107650192-e2b71980-6c86-11eb-9736-7f8bf71dd05f.png)
