### PR TITLE
Add modalComponent prop

### DIFF
--- a/src/tooltip.d.ts
+++ b/src/tooltip.d.ts
@@ -123,6 +123,9 @@ declare module 'react-native-walkthrough-tooltip' {
      *Set this to false if you want to override the default accessible on the root TouchableWithoutFeedback
      */
     accessible?: boolean;
+
+    /** Will use given component instead of default react-native Modal component **/
+    modalComponent?: object;
   }
 
   /**

--- a/src/tooltip.js
+++ b/src/tooltip.js
@@ -428,22 +428,23 @@ class Tooltip extends Component {
   };
 
   render() {
-    const { children, isVisible, useReactNativeModal } = this.props;
+    const { children, isVisible, useReactNativeModal, modalComponent } = this.props;
 
     const hasChildren = React.Children.count(children) > 0;
     const showTooltip = isVisible && !this.state.waitingForInteractions;
+    const ModalComponent = modalComponent || Modal;
 
     return (
       <React.Fragment>
         {useReactNativeModal ? (
-          <Modal
+          <ModalComponent
             transparent
             visible={showTooltip}
             onRequestClose={this.props.onClose}
             supportedOrientations={this.props.supportedOrientations}
           >
             {this.renderContentForTooltip()}
-          </Modal>
+          </ModalComponent>
         ) : null}
 
         {/* This renders the child element in place in the parent's layout */}


### PR DESCRIPTION
In some cases, the default Modal component from react-native should be replaced by another one (typically, when using a library such as `react-native-web`).
The new prop `modalComponent` will allow you to achieve that, with minimal code changes.
Feel free to ask if I need to edit something.