### PR TITLE
Added parentWrapperStyle prop

### DIFF
--- a/src/tooltip.d.ts
+++ b/src/tooltip.d.ts
@@ -44,6 +44,9 @@ declare module 'react-native-walkthrough-tooltip' {
 
     // Styles the View element that wraps the children to clone it
     childrenWrapperStyle?: StyleProp<ViewStyle>;
+
+    // Styles the view element that wraps the original children
+    parentWrapperStyle?: StyleProp<ViewStyle>
   }
 
   export interface TooltipProps extends Partial<TooltipStyleProps> {

--- a/src/tooltip.js
+++ b/src/tooltip.js
@@ -467,7 +467,11 @@ class Tooltip extends Component {
 
         {/* This renders the child element in place in the parent's layout */}
         {hasChildren ? (
-          <View ref={this.childWrapper} onLayout={this.measureChildRect}>
+          <View
+            ref={this.childWrapper}
+            onLayout={this.measureChildRect}
+            style={this.props.parentWrapperStyle}
+          >
             {children}
           </View>
         ) : null}


### PR DESCRIPTION
Added parentWrapperStyle prop that can be used to control the style of the wrapper view surrounding the original child component.

This is needed for cases where we need to style the children component using % or pretty much any styling that will be prevented by the parent wrapper.