### PR TITLE
Fix removeEventListener deprecated warning

### DIFF
--- a/src/tooltip.js
+++ b/src/tooltip.js
@@ -163,12 +163,12 @@ class Tooltip extends Component {
   componentWillUnmount() {
     // removeEventListener deprecated
     // https://reactnative.dev/docs/dimensions#removeeventlistener
-    if (Dimensions.removeEventListener) {
-      // react native < 0.65.*
-      Dimensions.removeEventListener('change', this.updateWindowDims);
-    } else if (this.dimensionsSubscription) {
+    if (this.dimensionsSubscription?.remove) {
       // react native >= 0.65.*
       this.dimensionsSubscription.remove();
+    } else {
+      // react native < 0.65.*
+      Dimensions.removeEventListener('change', this.updateWindowDims);
     }
 
     if (this.interactionPromise) {


### PR DESCRIPTION
Fix #123

The previous from #126 didn't fix the deprecation warning, as it's just a deprecation warning, which means checking `Dimensions.removeEventListener` will still remain non-faulty, and it will still be called in RN 0.65+ until RN team officially remove `removeEventListener`.