### PR TITLE
@types/react support for version 17

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "react-native": "^0.55.3"
   },
   "peerDependencies": {
-    "@types/react": "^16.8.24"
+    "@types/react": ">=16.8.24 <18"
   },
   "jest": {
     "preset": "react-native",


### PR DESCRIPTION
Hi,

I am getting dependency resolving issues when trying to update the version of @types/react, so I'm proposing a wider SEMVER support for this peer dependency.

While this issue can be easily skipped by forcing the legacy peer dependencies, I believe it will be better to just support version 17 here

Please let me know if this makes sense for you.
Thanks for this great library!