### PR TITLE
Add children to TooltipProps

### DIFF
--- a/src/tooltip.d.ts
+++ b/src/tooltip.d.ts
@@ -129,6 +129,9 @@ declare module 'react-native-walkthrough-tooltip' {
 
     /** Will use given component instead of default react-native Modal component **/
     modalComponent?: object;
+
+    // Support for nested elements within the Tooltip component.
+    children?: React.ReactNode
   }
 
   /**

--- a/src/tooltip.d.ts
+++ b/src/tooltip.d.ts
@@ -131,7 +131,7 @@ declare module 'react-native-walkthrough-tooltip' {
     modalComponent?: object;
 
     // Support for nested elements within the Tooltip component.
-    children?: React.ReactNode
+    children?: React.ReactNode;
   }
 
   /**


### PR DESCRIPTION
Fixes the following error which occurs when trying to nest anything within the tooltip:
```
Property 'children' does not exist on type 'IntrinsicAttributes & IntrinsicClassAttributes<Tooltip> & Readonly<TooltipProps>'.
```