### PR TITLE
Add animation and animation types for native modal

### DIFF
--- a/src/tooltip.d.ts
+++ b/src/tooltip.d.ts
@@ -146,6 +146,9 @@ declare module 'react-native-walkthrough-tooltip' {
 
     // Support for nested elements within the Tooltip component.
     children?: React.ReactNode;
+
+    //Set animation for React Native modal. Default is 'none'
+    animationType?: 'none' | 'fade' | 'slide';
   }
 
   /**

--- a/src/tooltip.d.ts
+++ b/src/tooltip.d.ts
@@ -149,6 +149,11 @@ declare module 'react-native-walkthrough-tooltip' {
 
     //Set animation for React Native modal. Default is 'none'
     animationType?: 'none' | 'fade' | 'slide';
+
+    skipText?: string;
+    SkipTextStyle?: StyleProp<ViewStyle>;
+    SkipFunction?: () => void;
+    
   }
 
   /**

--- a/src/tooltip.js
+++ b/src/tooltip.js
@@ -77,6 +77,7 @@ class Tooltip extends Component {
     topAdjustment: 0,
     horizontalAdjustment: 0,
     accessible: true,
+    animationType: 'none',
   };
 
   static propTypes = {
@@ -109,6 +110,7 @@ class Tooltip extends Component {
     topAdjustment: PropTypes.number,
     horizontalAdjustment: PropTypes.number,
     accessible: PropTypes.bool,
+    animationType: PropTypes.string,
   };
 
   constructor(props) {
@@ -474,6 +476,7 @@ class Tooltip extends Component {
             visible={showTooltip}
             onRequestClose={this.props.onClose}
             supportedOrientations={this.props.supportedOrientations}
+            animationType={this.props.animationType}
           >
             {this.renderContentForTooltip()}
           </ModalComponent>

--- a/src/tooltip.js
+++ b/src/tooltip.js
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import React, { Component, Fragment } from 'react';
 import PropTypes from 'prop-types';
 import {
   Dimensions,
@@ -78,6 +78,8 @@ class Tooltip extends Component {
     horizontalAdjustment: 0,
     accessible: true,
     animationType: 'none',
+    skipText: 'Skip',
+    skipFunction: () => {},
   };
 
   static propTypes = {
@@ -111,6 +113,9 @@ class Tooltip extends Component {
     horizontalAdjustment: PropTypes.number,
     accessible: PropTypes.bool,
     animationType: PropTypes.string,
+    skipText: PropTypes.string,
+    skipStyle: PropTypes.object,
+    skipFunction: PropTypes.func,
   };
 
   constructor(props) {
@@ -431,27 +436,38 @@ class Tooltip extends Component {
         onPress={onPressBackground}
         accessible={this.props.accessible}
       >
-        <View style={generatedStyles.containerStyle}>
-          <View style={[generatedStyles.backgroundStyle]}>
-            <View style={generatedStyles.tooltipStyle}>
-              {hasChildren ? <View style={generatedStyles.arrowStyle} /> : null}
-              <View
-                onLayout={this.measureContent}
-                style={generatedStyles.contentStyle}
-              >
-                <TouchableWithoutFeedback
-                  onPress={onPressContent}
-                  accessible={this.props.accessible}
+        <Fragment>
+          <TouchableOpacity
+            onPress={this.props.handleSkip}
+            style={{ position: 'absolute', top: 0, right: 10, zIndex: 600 }}
+          >
+            <Text style={this.props.skipTextStyle}>{this.props.skipText}</Text>
+          </TouchableOpacity>
+
+          <View style={generatedStyles.containerStyle}>
+            <View style={[generatedStyles.backgroundStyle]}>
+              <View style={generatedStyles.tooltipStyle}>
+                {hasChildren ? (
+                  <View style={generatedStyles.arrowStyle} />
+                ) : null}
+                <View
+                  onLayout={this.measureContent}
+                  style={generatedStyles.contentStyle}
                 >
-                  {this.props.content}
-                </TouchableWithoutFeedback>
+                  <TouchableWithoutFeedback
+                    onPress={onPressContent}
+                    accessible={this.props.accessible}
+                  >
+                    {this.props.content}
+                  </TouchableWithoutFeedback>
+                </View>
               </View>
             </View>
+            {hasChildren && this.props.showChildInTooltip
+              ? this.renderChildInTooltip()
+              : null}
           </View>
-          {hasChildren && this.props.showChildInTooltip
-            ? this.renderChildInTooltip()
-            : null}
-        </View>
+        </Fragment>
       </TouchableWithoutFeedback>
     );
   };


### PR DESCRIPTION
There may be a blink effect when switching between modals. We can use the default React Native Modal animations to avoid it.