### PR TITLE
backgroundStyle prop is usable now to make the backdrop customizable

### DIFF
--- a/src/tooltip.js
+++ b/src/tooltip.js
@@ -430,7 +430,7 @@ class Tooltip extends Component {
         accessible={this.props.accessible}
       >
         <View style={generatedStyles.containerStyle}>
-          <View style={[generatedStyles.backgroundStyle]}>
+          <View style={[generatedStyles.backgroundStyle, this.props.backgroundStyle]}>
             <View style={generatedStyles.tooltipStyle}>
               {hasChildren ? <View style={generatedStyles.arrowStyle} /> : null}
               <View


### PR DESCRIPTION
We cannot customize the `backgroundStyle` of the tooltip and even we could not hide the backdrop. 

Now, we can do it :) 

Also solves #169 


Example usage:

```tsx
 <Tooltip
     isVisible={isVisible}
     content={<Text>Check this out!</Text>}
     backgroundStyle={{ backgroundColor: 'transparent' }}>
        <TextInput
              placeholder={emailPlaceholder}
              onChangeText={handleEmailChange}
              autoCapitalize="none"
              {...emailTextInputProps}
         />
</Tooltip>
```