### PR TITLE
Add a new prop to make the tooltip wrapper scrollable for small screen devices.

### DIFF
--- a/src/tooltip.d.ts
+++ b/src/tooltip.d.ts
@@ -46,7 +46,7 @@ declare module 'react-native-walkthrough-tooltip' {
     childrenWrapperStyle?: StyleProp<ViewStyle>;
 
     // Styles the view element that wraps the original children
-    parentWrapperStyle?: StyleProp<ViewStyle>
+    parentWrapperStyle?: StyleProp<ViewStyle>;
   }
 
   export interface TooltipProps extends Partial<TooltipStyleProps> {
@@ -146,6 +146,9 @@ declare module 'react-native-walkthrough-tooltip' {
 
     // Support for nested elements within the Tooltip component.
     children?: React.ReactNode;
+
+    // Make the tooltip wrapper scrollable.
+    scrollable?: boolean;
   }
 
   /**

--- a/src/tooltip.js
+++ b/src/tooltip.js
@@ -77,6 +77,7 @@ class Tooltip extends Component {
     topAdjustment: 0,
     horizontalAdjustment: 0,
     accessible: true,
+    scrollable: false,
   };
 
   static propTypes = {
@@ -109,6 +110,7 @@ class Tooltip extends Component {
     topAdjustment: PropTypes.number,
     horizontalAdjustment: PropTypes.number,
     accessible: PropTypes.bool,
+    scrollable: PropTypes.bool,
   };
 
   constructor(props) {
@@ -408,7 +410,7 @@ class Tooltip extends Component {
     const hasChildren = React.Children.count(this.props.children) > 0;
     const screenHeight = Dimensions.get('window').height;
 
-    if (screenHeight < 700) {
+    if (this.props.scrollable) {
       generatedStyles.containerStyle = {
         ...generatedStyles.containerStyle,
         height: screenHeight * 1.3,

--- a/src/tooltip.js
+++ b/src/tooltip.js
@@ -32,10 +32,10 @@ const DEFAULT_DISPLAY_INSETS = {
   right: 24,
 };
 
-const computeDisplayInsets = insetsFromProps =>
+const computeDisplayInsets = (insetsFromProps) =>
   Object.assign({}, DEFAULT_DISPLAY_INSETS, insetsFromProps);
 
-const invertPlacement = placement => {
+const invertPlacement = (placement) => {
   switch (placement) {
     case 'top':
       return 'bottom';
@@ -212,7 +212,7 @@ class Tooltip extends Component {
     return null;
   }
 
-  updateWindowDims = dims => {
+  updateWindowDims = (dims) => {
     this.setState(
       {
         windowDims: dims.window,
@@ -241,7 +241,7 @@ class Tooltip extends Component {
     );
   };
 
-  measureContent = e => {
+  measureContent = (e) => {
     const { width, height } = e.nativeEvent.layout;
     const contentSize = new Size(width, height);
     this.setState({ contentSize }, () => {
@@ -249,7 +249,7 @@ class Tooltip extends Component {
     });
   };
 
-  onChildMeasurementComplete = rect => {
+  onChildMeasurementComplete = (rect) => {
     this.setState(
       {
         childRect: rect,
@@ -276,7 +276,7 @@ class Tooltip extends Component {
             (x, y, width, height, pageX, pageY) => {
               const childRect = new Rect(pageX, pageY, width, height);
               if (
-                Object.values(childRect).every(value => value !== undefined)
+                Object.values(childRect).every((value) => value !== undefined)
               ) {
                 this.onChildMeasurementComplete(childRect);
               } else {
@@ -304,13 +304,8 @@ class Tooltip extends Component {
 
   computeGeometry = () => {
     const { arrowSize, childContentSpacing } = this.props;
-    const {
-      childRect,
-      contentSize,
-      displayInsets,
-      placement,
-      windowDims,
-    } = this.state;
+    const { childRect, contentSize, displayInsets, placement, windowDims } =
+      this.state;
 
     const options = {
       displayInsets,
@@ -411,12 +406,15 @@ class Tooltip extends Component {
     });
 
     const hasChildren = React.Children.count(this.props.children) > 0;
+    const screenHeight = Dimensions.get('window').height;
 
-    const onPressBackground = () => {
-      if (this.props.closeOnBackgroundInteraction) {
-        this.props.onClose();
-      }
-    };
+    if (screenHeight < 700) {
+      generatedStyles.containerStyle = {
+        ...generatedStyles.containerStyle,
+        height: screenHeight * 1.3,
+        backgroundColor: 'rgba(0,0,0, 0.5)',
+      };
+    }
 
     const onPressContent = () => {
       if (this.props.closeOnContentInteraction) {
@@ -426,10 +424,10 @@ class Tooltip extends Component {
 
     return (
       <TouchableWithoutFeedback
-        onPress={onPressBackground}
+        onPress={this.props.onClose}
         accessible={this.props.accessible}
       >
-        <View style={generatedStyles.containerStyle}>
+        <ScrollView contentContainerStyle={generatedStyles.containerStyle}>
           <View style={[generatedStyles.backgroundStyle]}>
             <View style={generatedStyles.tooltipStyle}>
               {hasChildren ? <View style={generatedStyles.arrowStyle} /> : null}
@@ -449,18 +447,14 @@ class Tooltip extends Component {
           {hasChildren && this.props.showChildInTooltip
             ? this.renderChildInTooltip()
             : null}
-        </View>
+        </ScrollView>
       </TouchableWithoutFeedback>
     );
   };
 
   render() {
-    const {
-      children,
-      isVisible,
-      useReactNativeModal,
-      modalComponent,
-    } = this.props;
+    const { children, isVisible, useReactNativeModal, modalComponent } =
+      this.props;
 
     const hasChildren = React.Children.count(children) > 0;
     const showTooltip = isVisible && !this.state.waitingForInteractions;

--- a/src/tooltip.js
+++ b/src/tooltip.js
@@ -6,6 +6,7 @@ import {
   Modal,
   TouchableWithoutFeedback,
   View,
+  ScrollView,
 } from 'react-native';
 import rfcIsEqual from 'react-fast-compare';
 import {


### PR DESCRIPTION
By passing `scrollable={true}` users will be able to scroll the content of a tooltip if they are using a small screen device and they have problems with the tooltips.